### PR TITLE
Pause System Integration for GameClock

### DIFF
--- a/Assets/Scripts/Managers/GameClock.cs
+++ b/Assets/Scripts/Managers/GameClock.cs
@@ -14,6 +14,7 @@ public class GameClock : MonoBehaviour
 
     // Configuration: Adjust the real-time to game-time multiplier and the duration of a game day (in seconds)
     public float realTimeToGameTimeMultiplier = 1f; // How many seconds in real time equals one second in game time
+    private float originalTimeMultiplier = 1f; // Store the original speed when paused
     public float gameDayDuration = 14f * 60f; // Total duration of a game day in real seconds (default: 14 minutes)
     private const float gameHoursPerDay = 24f; // Total in-game hours in a day
 
@@ -176,6 +177,31 @@ public class GameClock : MonoBehaviour
         if (elapsedGameTime >= gameDayDuration) // If skipping exceeds the current day duration
         {
             EndDay(); // End the day and reset the clock
+        }
+    }
+
+    /// <summary>
+    /// Pauses the in-game clock by setting the time multiplier to 0.
+    /// </summary>
+    public void PauseClock()
+    {
+        if (realTimeToGameTimeMultiplier != 0f) // Prevent overwriting pause state
+        {
+            originalTimeMultiplier = realTimeToGameTimeMultiplier; // Store current speed
+            realTimeToGameTimeMultiplier = 0f; // Stop time progression
+            Debug.Log("GameClock paused.");
+        }
+    }
+
+    /// <summary>
+    /// Resumes the in-game clock by restoring the previous time multiplier.
+    /// </summary>
+    public void ResumeClock()
+    {
+        if (realTimeToGameTimeMultiplier == 0f) // Only resume if actually paused
+        {
+            realTimeToGameTimeMultiplier = originalTimeMultiplier; // Restore time speed
+            Debug.Log("GameClock resumed.");
         }
     }
 

--- a/Assets/Scripts/Managers/MenuManager.cs
+++ b/Assets/Scripts/Managers/MenuManager.cs
@@ -4,40 +4,88 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
+/// <summary>
+/// Manages the in-game menu and pause functionality.
+/// Allows toggling the menu via the "Cancel" button (typically ESC).
+/// Handles pausing and resuming the game clock when the menu is opened or closed.
+/// Implements a cooldown to prevent rapid toggling.
+/// </summary>
 public class MenuManager : MonoBehaviour
 {
-    public static MenuManager Instance;
+    public static MenuManager Instance; // Singleton instance
 
+    [Tooltip("Reference to the in-game player menu UI.")]
     public GameObject PlayerMenu;
 
+    [Tooltip("Indicates whether the game is currently paused.")]
     public bool isPaused = false;
 
-    private void Awake() // Singleton
+    private bool canToggle = true; // Prevents rapid toggling of the menu
+
+    private void Awake()
     {
+        // Ensure only one instance of MenuManager exists (Singleton pattern)
         if (Instance == null)
         {
             Instance = this;
-            DontDestroyOnLoad(gameObject);
+            DontDestroyOnLoad(gameObject); // Persist across scene loads
         }
-        else 
+        else
         {
-            Destroy(gameObject);
+            Destroy(gameObject); // Destroy duplicate instances
         }
     }
 
     private void Update()
     {
-        if (Input.GetButtonDown("Cancel") && !DialogueManager.Instance.isTalking) // Opens or closes the menu if not talking
+        // Check for "Cancel" button (Escape key by default) and ensure dialogue is not active
+        if (Input.GetButtonDown("Cancel") && !DialogueManager.Instance.isTalking)
         {
-            isPaused = !isPaused;
-            PlayerMenu.SetActive(!(PlayerMenu.activeSelf));
+            TogglePause();
         }
     }
 
-    public void unPause() // This is for the button
+    /// <summary>
+    /// Cooldown coroutine to prevent rapid toggling of the menu.
+    /// Ensures the toggle function isn't called multiple times in quick succession.
+    /// </summary>
+    public IEnumerator TogglePauseCooldown()
     {
-        PlayerMenu.SetActive(!(PlayerMenu.activeSelf));
-        isPaused = !isPaused;
+        canToggle = false; // Disable further toggles
+        yield return new WaitForSeconds(0.2f); // Small delay before allowing toggling again
+        canToggle = true; // Enable toggling
     }
 
+    /// <summary>
+    /// Toggles the pause state, showing or hiding the menu and pausing/resuming game time.
+    /// </summary>
+    public void TogglePause()
+    {
+        if (!canToggle) return; // Prevent spam-clicking
+
+        bool isMenuOpen = PlayerMenu.activeSelf; // Check if the menu is currently open
+        isPaused = !isMenuOpen; // Update pause state
+        PlayerMenu.SetActive(isPaused); // Show/hide the menu UI
+
+        // Pause or resume the game clock if it exists
+        if (GameClock.Instance != null)
+        {
+            if (isPaused)
+                GameClock.Instance.PauseClock();
+            else
+                GameClock.Instance.ResumeClock();
+        }
+
+        StartCoroutine(TogglePauseCooldown()); // Start cooldown to prevent spam
+        Debug.Log($"Menu Toggled - isPaused: {isPaused}"); // Log state change for debugging
+    }
+
+    /// <summary>
+    /// Closes the menu and resumes the game.
+    /// This is called by the "Close" button inside the UI menu.
+    /// </summary>
+    public void unPause()
+    {
+        TogglePause();
+    }
 }


### PR DESCRIPTION
Summary

This update implements a pause system for the GameClock and refines menu interactions to prevent unintended toggles. The pause system ensures that in-game time halts when the menu is opened and resumes upon closing.
Changes Implemented

Pause System for GameClock

-     Added PauseClock() and ResumeClock() functions in GameClock.cs to control time progression.
-     realTimeToGameTimeMultiplier is set to 0f when paused and 1f when resumed.

MenuManager Enhancements

-     Implemented TogglePauseCooldown() to prevent rapid toggling.
-     Refactored TogglePause() to ensure proper menu state handling.
-     Integrated GameClock pause/resume functionality into menu interactions.

Impact & Next Steps

-     The pause system is now functional, and game time correctly stops while the menu is open.
-     This lays the groundwork for future pause integration with additional features.