### PR TITLE
Game Clock System Updates - Manual Sleep Mode, Dev Tools & Force Sleep

### DIFF
--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -31,11 +33,20 @@ public class GameManager : MonoBehaviour
     /// </summary>
     private string locationKey = "";
 
-
     /// <summary>
     /// The players Gameobject
     /// </summary>
     private GameObject playerGameObject;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public bool DeveloperModeEnabled { get; private set; } = false;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public event Action OnDeveloperModeToggled;
 
     private void Awake()
     {
@@ -56,17 +67,10 @@ public class GameManager : MonoBehaviour
 
     private void Update()
     {
-        if (Input.GetKeyDown(KeyCode.P)) // Press 'P' to print task list
+        HandleDeveloperModeToggle();
+        if (DeveloperModeEnabled)
         {
-            TaskManager.Instance.PrintTaskList();
-        }
-        if (Input.GetKeyDown(KeyCode.O)) // Press 'O' to print task list
-        {
-            TaskManager.Instance.PrintAllTasksToConsole();
-        }
-        if (Input.GetKeyDown(KeyCode.N)) // Press 'N' to end the day
-        {
-            GameClock.Instance.EndDayNow();
+            HandleDeveloperTools();
         }
     }
     
@@ -138,5 +142,63 @@ public class GameManager : MonoBehaviour
         return false;
     }
 
+    private void HandleDeveloperModeToggle()
+    {
+        if (Input.GetKeyDown(KeyCode.F1))
+        {
+            DeveloperModeEnabled = !DeveloperModeEnabled;
+            OnDeveloperModeToggled?.Invoke();
+            Debug.Log($"Developer Mode {(DeveloperModeEnabled ? "Enabled" : "Disabled")}");
+            if (DeveloperModeEnabled)
+            {
+                PrintDeveloperHotkeys();
+            }
+        }
+    }
+    private void HandleDeveloperTools()
+    {
+        if (Input.GetKeyDown(KeyCode.F2))
+        {
+            TaskManager.Instance.PrintTaskList();
+        }
+        if (Input.GetKeyDown(KeyCode.F3))
+        {
+            TaskManager.Instance.PrintAllTasksToConsole();
+        }
+        if (Input.GetKeyDown(KeyCode.F4))
+        {
+            GameClock.Instance.GoToSleep();
+        }        
+        if (Input.GetKeyDown(KeyCode.F5))
+        {
+            GameClock.Instance.SkipTime(1);
+        }
+        if (Input.GetKeyDown(KeyCode.F6))
+        {
+            GameClock.Instance.SkipTime(4);
+        }
+        if (Input.GetKeyDown(KeyCode.F7))
+        {
+            GameClock.Instance.SetDay(GameClock.Instance.currentDay + 1);
+        }
+        if (Input.GetKeyDown(KeyCode.F12))
+        {
+            GameClock.Instance.ForceSleep();
+        }
+    }
+
+    private void PrintDeveloperHotkeys()
+    {
+        Debug.Log("Developer Mode Hotkeys:\n" +
+                  "F2 - Print Task List\n" +
+                  "F3 - Print All Tasks\n" +
+                  "F4 - Go To Sleep (End Day)\n" +
+                  "F5 - Skip 1 Hour\n" +
+                  "F6 - Skip 4 Hours\n" +
+                  "F7 - Set Next Day\n" +
+                  "F9 - Toggle Verbose Clock Logging\n" +
+                  "F12 - Force Sleep & End Day\n");
+    }
 }
+
 

--- a/Assets/Scripts/Tests/GameClockVerboseTester.cs
+++ b/Assets/Scripts/Tests/GameClockVerboseTester.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 public class GameClockVerboseTester : MonoBehaviour
 {
     private GameClock gameClock;
+    private bool verboseLoggingEnabled = false;
 
     private void Start()
     {
@@ -22,11 +23,10 @@ public class GameClockVerboseTester : MonoBehaviour
 
     private void Update()
     {
-        // Check for manual time skip input
-        if (Input.GetKeyDown(KeyCode.T))
+        if (GameManager.Instance != null && GameManager.Instance.DeveloperModeEnabled && Input.GetKeyDown(KeyCode.F9))
         {
-            Debug.Log("Manual time skipping triggered: Skipping 3 hours...");
-            gameClock.SkipTime(3f); // Skip 3 game hours
+            verboseLoggingEnabled = !verboseLoggingEnabled;
+            Debug.Log($"Verbose Clock Logging {(verboseLoggingEnabled ? "Enabled" : "Disabled")}");
         }
     }
 
@@ -34,22 +34,25 @@ public class GameClockVerboseTester : MonoBehaviour
     {
         while (true)
         {
-            // Print game clock details every 5 seconds
-            Debug.Log($"[Game Clock Update] Day: {gameClock.currentDay}, Hour: {gameClock.currentHour:F2}");
-            Debug.Log($"Elapsed Game Time: {gameClock.elapsedGameTime:F2}s / {gameClock.gameDayDuration}s");
-            Debug.Log($"Current State: {gameClock.CurrentState}");
-
-            // Test day/night transitions
-            if (gameClock.CurrentState == GameClock.ClockState.Night)
+            if (GameManager.Instance != null && GameManager.Instance.DeveloperModeEnabled && verboseLoggingEnabled)
             {
-                Debug.Log("It's nighttime! Players should head to bed.");
-            }
-            else if (gameClock.CurrentState == GameClock.ClockState.Day)
-            {
-                Debug.Log("It's daytime! Time to explore and complete tasks.");
+                // Print game clock details every 5 seconds only if Developer Mode and Verbose Logging are enabled
+                Debug.Log($"[Game Clock Update] Day: {gameClock.currentDay}, Hour: {gameClock.currentHour:F2}");
+                Debug.Log($"Elapsed Game Time: {gameClock.elapsedGameTime:F2}s / {gameClock.gameDayDuration}s");
+                Debug.Log($"Current State: {gameClock.CurrentState}");
+
+                // Test day/night transitions
+                if (gameClock.CurrentState == GameClock.ClockState.Night)
+                {
+                    Debug.Log("It's nighttime! Players should head to bed.");
+                }
+                else if (gameClock.CurrentState == GameClock.ClockState.Day)
+                {
+                    Debug.Log("It's daytime! Time to explore and complete tasks.");
+                }
             }
 
-            // Add a delay of 15 real seconds before next update
+            // Add a delay of 5 real seconds before the next update
             yield return new WaitForSeconds(5f);
         }
     }


### PR DESCRIPTION
This update enhances the Game Clock System by adding a Manual Sleep Mode, improving developer tools, refining time management logic, and introducing a Force Sleep option. These changes allow better control over in-game time, testing, and debugging.
Key Updates:

Manual Sleep Mode (Default)

    Time now freezes at midnight in manual mode instead of automatically ending the day.
    The game enters a Sleep Pending State, requiring the player to interact with a bed or manually trigger sleep (GoToSleep()).

Auto-Sleep Mode (Optional)

    The original automatic day rollover mode is still available for testing/debugging.
    Toggle between Manual and Auto mode with SetManualSleepMode(bool enable).

Developer Tools

    F1 → Toggle Developer Mode (shows all available hotkeys in the console).
    F2 → Print Task List.
    F3 → Print All Tasks.
    F4 → Go To Sleep (End Day).
    F5 → Skip 1 Hour.
    F6 → Skip 4 Hours.
    F7 → Set Next Day.
    F9 → Toggle Verbose Clock Logging (Only logs time updates when enabled).
    F12 → Force Sleep (Instantly ends the day, even outside of Sleep Pending mode).

Verbose Game Clock Logging (Debugging)

    Added GameClockVerboseTester.cs to print time progression logs.
    Only logs when Developer Mode & Verbose Logging are both enabled.
    Toggle Verbose Logging with F9.

Bug Fixes & Improvements

    Prevented currentHour from exceeding 24 (fixing UI display issues when skipping time).
    Added more robust save/load logic to persist time and day states properly.
    Improved comments & documentation for better clarity.