### PR TITLE
Bed Interaction Implementation & Tint Overlay Fixes.

### DIFF
--- a/Assets/Prefabs/Bed.prefab
+++ b/Assets/Prefabs/Bed.prefab
@@ -1,0 +1,295 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1878141992703728149
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2075266201029409851}
+  - component: {fileID: 5238935229514210788}
+  - component: {fileID: 8526202283036559256}
+  - component: {fileID: 1199582556894608503}
+  - component: {fileID: 4140783037674859658}
+  m_Layer: 0
+  m_Name: Bed
+  m_TagString: Interactable
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2075266201029409851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878141992703728149}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -4.0024, y: 1.6737, z: 0}
+  m_LocalScale: {x: 3.0174181, y: 3.1035151, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2601031225231521515}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &5238935229514210788
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878141992703728149}
+  m_Enabled: 0
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 1276794309
+  m_SortingLayer: 2
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!1839735485 &8526202283036559256
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878141992703728149}
+  m_Enabled: 1
+  m_Tiles: {}
+  m_AnimatedTiles: {}
+  m_TileAssetArray: []
+  m_TileSpriteArray: []
+  m_TileMatrixArray: []
+  m_TileColorArray: []
+  m_TileObjectToInstantiateArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Origin: {x: 0, y: 0, z: 0}
+  m_Size: {x: 0, y: 0, z: 1}
+  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+--- !u!61 &1199582556894608503
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878141992703728149}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!50 &4140783037674859658
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1878141992703728149}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!1 &6531961048076858960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2601031225231521515}
+  - component: {fileID: 4480503528288992795}
+  - component: {fileID: 267157257277797487}
+  m_Layer: 0
+  m_Name: Interact
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2601031225231521515
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6531961048076858960}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.6787093, y: -3.2904904, z: 0}
+  m_LocalScale: {x: 0.59495145, y: 0.38975307, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2075266201029409851}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &4480503528288992795
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6531961048076858960}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: -4.509508, y: 8.507214}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1.3324988, y: 2.439495}
+  m_EdgeRadius: 0
+--- !u!114 &267157257277797487
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6531961048076858960}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f103357ac82c60644be9f9770c4f2d5a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Bed.prefab.meta
+++ b/Assets/Prefabs/Bed.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8c7d861b71292254c905fe9696aa5303
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/PlayerHome.unity
+++ b/Assets/Scenes/PlayerHome.unity
@@ -1583,6 +1583,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 5035991868350993731}
   - {fileID: 1360645706}
   m_Father: {fileID: 2112482364}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3368,7 +3369,7 @@ PrefabInstance:
     - target: {fileID: 1209098923972178090, guid: d37352c904bb7074fa28dd79f9517706, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 626026994}
+      objectReference: {fileID: 0}
     - target: {fileID: 1209098923972178090, guid: d37352c904bb7074fa28dd79f9517706, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
@@ -3450,17 +3451,6 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d37352c904bb7074fa28dd79f9517706, type: 3}
---- !u!114 &626026994 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 9120777313225347499, guid: d37352c904bb7074fa28dd79f9517706, type: 3}
-  m_PrefabInstance: {fileID: 626026993}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2ea4da17e6e253848b541e066302a15c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &741164264
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4608,6 +4598,97 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6842351580804605246, guid: e4472a72cd60bde45a5c6ca3878f702b, type: 3}
   m_PrefabInstance: {fileID: 7643227555651290198}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1733684367
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1733684368}
+  - component: {fileID: 1733684370}
+  - component: {fileID: 1733684371}
+  m_Layer: 0
+  m_Name: Interact
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1733684368
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1733684367}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.6787093, y: -3.2904904, z: 0}
+  m_LocalScale: {x: 0.59495145, y: 0.38975307, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5035991868350993731}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1733684370
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1733684367}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: -4.509508, y: 8.507214}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1.3324988, y: 2.439495}
+  m_EdgeRadius: 0
+--- !u!114 &1733684371
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1733684367}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f103357ac82c60644be9f9770c4f2d5a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2036008201
 GameObject:
   m_ObjectHideFlags: 0
@@ -5795,6 +5876,224 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9266c697df61ddd49964fe8e811e0afb, type: 3}
+--- !u!1001 &5035991868350993725
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 503515641}
+    m_Modifications:
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.0174181
+      objectReference: {fileID: 0}
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.1035151
+      objectReference: {fileID: 0}
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.0024
+      objectReference: {fileID: 0}
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6737
+      objectReference: {fileID: 0}
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490137885950014004, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_Color.a
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490137885950014004, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490137885950014004, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_SortingLayer
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2490137885950014004, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_SortingLayerID
+      value: 1276794309
+      objectReference: {fileID: 0}
+    - target: {fileID: 8092648419337052857, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_Name
+      value: Bed
+      objectReference: {fileID: 0}
+    - target: {fileID: 8092648419337052857, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      propertyPath: m_TagString
+      value: Interactable
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1733684368}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8092648419337052857, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5035991868350993729}
+    - targetCorrespondingSourceObject: {fileID: 8092648419337052857, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5035991868350993728}
+    - targetCorrespondingSourceObject: {fileID: 8092648419337052857, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5035991868350993733}
+  m_SourcePrefab: {fileID: 100100000, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+--- !u!1 &5035991868350993726 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8092648419337052857, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+  m_PrefabInstance: {fileID: 5035991868350993725}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &5035991868350993728
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5035991868350993726}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!1839735485 &5035991868350993729
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5035991868350993726}
+  m_Enabled: 1
+  m_Tiles: {}
+  m_AnimatedTiles: {}
+  m_TileAssetArray: []
+  m_TileSpriteArray: []
+  m_TileMatrixArray: []
+  m_TileColorArray: []
+  m_TileObjectToInstantiateArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Origin: {x: 0, y: 0, z: 0}
+  m_Size: {x: 0, y: 0, z: 1}
+  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+--- !u!4 &5035991868350993731 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 609318062333640514, guid: 4e26bbea55e5ecf42aaedab92c573340, type: 3}
+  m_PrefabInstance: {fileID: 5035991868350993725}
+  m_PrefabAsset: {fileID: 0}
+--- !u!50 &5035991868350993733
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5035991868350993726}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!1001 &7643227555651290198
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Managers/GameClock.cs
+++ b/Assets/Scripts/Managers/GameClock.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 /// <summary>
@@ -65,15 +66,7 @@ public class GameClock : MonoBehaviour
         LoadGameClockFromSave(GameManager.Instance.CurrentPlayerData);
         Debug.Log($"Loaded Clock Data from Save: Day {currentDay}");
 
-        // Get the Image component from the UI Panel
-        if (tintOverlayImage != null)
-        {
-            tintOverlayImage = tintOverlayImage.GetComponent<Image>();
-            if (tintOverlayImage == null)
-            {
-                Debug.LogError("No Image component found on the TintOverlay Panel!");
-            }
-        }
+        AssignTintOverlay(); // Reassign TintOverlay dynamically
 
         // Initialize the tint color based on the current state
         UpdateTintOverlay(true); // Initialize with instant transition
@@ -169,6 +162,17 @@ public class GameClock : MonoBehaviour
     private void EndDay()
     {
         OnDayEnd?.Invoke(); // Trigger day-end event
+
+        // Start a transition effect before resetting the day
+        if (TransitionManager.Instance != null)
+        {
+            TransitionManager.Instance.StartTransition(SceneManager.GetActiveScene().name, TransitionType.WIPE);
+        }
+        else
+        {
+            Debug.LogWarning("TransitionManager is null! Skipping transition.");
+        }
+
         currentDay++; // Increment the day counter
         elapsedGameTime = 0f; // Reset elapsed game time
         currentHour = 8f; // Reset to the start of the next day (8 AM)
@@ -351,6 +355,26 @@ public class GameClock : MonoBehaviour
         {
             // Smooth transition using Color.Lerp()
             tintOverlayImage.color = Color.Lerp(tintOverlayImage.color, targetTint, transitionSpeed * Time.deltaTime);
+        }
+    }
+
+    public void AssignTintOverlay()
+    {
+        // Find the TintOverlay object dynamically in the new scene
+        GameObject tintObj = GameObject.Find("TintOverlay");
+
+        if (tintObj != null)
+        {
+            tintOverlayImage = tintObj.GetComponent<Image>();
+
+            if (tintOverlayImage == null)
+            {
+                Debug.LogError("No Image component found on TintOverlay!");
+            }
+        }
+        else
+        {
+            Debug.LogError("TintOverlay not found in the current scene!");
         }
     }
 

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -107,6 +107,11 @@ public class GameManager : MonoBehaviour
             }
         }
 
+        if (GameClock.Instance != null)
+        {
+            GameClock.Instance.AssignTintOverlay(); // Ensure GameClock updates TintOverlay
+        }
+
     }
 
     /// <summary>

--- a/Assets/Scripts/Objects/Bed.cs
+++ b/Assets/Scripts/Objects/Bed.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+public class Bed : MonoBehaviour
+{
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.CompareTag("Player"))
+        {
+            Debug.Log("Near bed. Press E to sleep.");
+        }
+    }
+
+    private void OnTriggerStay2D(Collider2D collision)
+    {
+        if (collision.CompareTag("Player") && Input.GetButton("Jump") && !MenuManager.Instance.isPaused && !DialogueManager.Instance.isTalking)
+        {
+            Debug.Log("Player is sleeping...");
+            GameClock.Instance.GoToSleep(); // Trigger sleep routine
+        }
+    }
+}

--- a/Assets/Scripts/Objects/Bed.cs.meta
+++ b/Assets/Scripts/Objects/Bed.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f103357ac82c60644be9f9770c4f2d5a

--- a/Assets/Scripts/Objects/BedInteraction.cs
+++ b/Assets/Scripts/Objects/BedInteraction.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class BedInteraction : MonoBehaviour
+{
+    private bool isPlayerInRange = false;
+    [SerializeField] private GameObject interactionPrompt; // UI prompt message
+
+    private void Start()
+    {
+        if (interactionPrompt != null)
+        {
+            interactionPrompt.SetActive(false); // Hide prompt at start
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Player")) // Ensure it's the player
+        {
+            isPlayerInRange = true;
+            if (interactionPrompt != null)
+            {
+                interactionPrompt.SetActive(true); // Show prompt
+            }
+        }
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            isPlayerInRange = false;
+            if (interactionPrompt != null)
+            {
+                interactionPrompt.SetActive(false); // Hide prompt
+            }
+        }
+    }
+
+    private void Update()
+    {
+        if (isPlayerInRange && Input.GetKeyDown(KeyCode.E)) // Press E to interact
+        {
+            GameClock.Instance.ForceSleep(); // Test Trigger sleep routine
+            //GameClock.Instance.GoToSleep(); // Trigger sleep routine
+            Debug.Log("Player slept. New day begins.");
+        }
+    }
+}

--- a/Assets/Scripts/Objects/BedInteraction.cs.meta
+++ b/Assets/Scripts/Objects/BedInteraction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 847a317434f471c4c91ebbde8e6125b5

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 3
   tags:
   - Waypoint
+  - Interactable
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Fixed Tint Overlay Issues

    Ensured the tint overlay persists across scene reloads.
    Corrected issues where the tint overlay reference was lost when changing scenes.
    Made the tint overlay a prefab for consistency and easier scene management.

GameClock Enhancements

    Added a sleep interaction system using a bed prefab.
    Players can now interact with the bed to trigger the sleep routine and advance to the next day.
    Integrated day-ending logic into the bed interaction.

Transitions & Scene Management

    Implemented WIPE transition at the end of the day to improve scene transitions.
    Fixed method call errors and ensured compatibility with TransitionManager.cs.
    
Bug Fixes & Stability Improvements

    Resolved issues with the tint overlay disappearing after reloading scenes.
    Fixed input-related interactions with doors and beds.
    Verified GameClock, TaskManager, and PlayerProgressManager function correctly post-transition.